### PR TITLE
Fix Bug

### DIFF
--- a/lib/docomo-nlu/management/V26/base.rb
+++ b/lib/docomo-nlu/management/V26/base.rb
@@ -47,7 +47,7 @@ module DocomoNlu
       class << self
         def instantiate_collection(collection, original_params = {}, prefix_options = {})
           if collection.is_a?(Hash)
-            collection = if collection.empty? || collection.first[1].nil?
+            collection = if collection.compact.empty?
                            []
                          else
                            [collection]


### PR DESCRIPTION
Fix the case of not Initialized object when a collection has nil attribute as first object such as {"key1": nil, "key2": "..."} .