### PR TITLE
Updated rubocop-rspec 1.35.0

### DIFF
--- a/.rubocop.rspec.yml
+++ b/.rubocop.rspec.yml
@@ -60,3 +60,8 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+# 明示的なブロック構文の使用を推奨しているがsubjectの活用が減る可能性があるので
+# 暗黙的なブロック構文を許可する
+RSpec/ImplicitBlockExpectation:
+  Enabled: false 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
-    parser (2.6.3.0)
+    parser (2.6.4.1)
       ast (~> 2.4.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -176,7 +176,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.4.1)
       rubocop (>= 0.71.0)
-    rubocop-rspec (1.34.1)
+    rubocop-rspec (1.35.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
     rubyzip (1.2.3)
@@ -219,7 +219,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-performance
-  rubocop-rspec (~> 1.34.0)
+  rubocop-rspec (~> 1.35.0)
   vcr (~> 4.0.0)
   webmock (~> 3.4.2)
 

--- a/docomo-nlu.gemspec
+++ b/docomo-nlu.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "rubocop-performance"
-  spec.add_development_dependency "rubocop-rspec", "~> 1.34.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.35.0"
   spec.add_development_dependency "vcr", "~> 4.0.0"
   spec.add_development_dependency "webmock", "~> 3.4.2"
 end


### PR DESCRIPTION
## feature
Updated rubocop-rspec 1.35.0

[SEBAMAINAG-1306](https://jira.docomo-common.com/browse/SEBAMAINAG-1306)

## 対応
- [x] gemspec修正
- [x] RSpec/ImplicitBlockExpectation 無効化